### PR TITLE
Type assertion instead of switching on type

### DIFF
--- a/glog.go
+++ b/glog.go
@@ -561,11 +561,8 @@ func (buf *buffer) someDigits(i, d int) int {
 func getStackFrames(args []interface{}) []uintptr {
 	var frames []uintptr
 	for _, arg := range args {
-		switch e := arg.(type) {
-		case error:
-			return errgo.StackFrameInfo(e)
-		default:
-			// ignore
+		if err, ok := arg.(error); ok {
+			return errgo.StackFrameInfo(err)
 		}
 	}
 	return frames


### PR DESCRIPTION
Since this is only checking for one type, it's a little faster to just do a type assertion (also it's a little more readable as there's no default). Just thought y'all might be interested!

Some (ugly) benchmarking:
https://gist.github.com/ttacon/757bdf2b6ae5bc1322c7
