### PR TITLE
backend: pass errors through, with special support for xerrors

### DIFF
--- a/glog_backend.go
+++ b/glog_backend.go
@@ -30,7 +30,7 @@ type Event struct {
 	Severity   string
 	Message    []byte
 	Data       []interface{}
-	StackTrace []uintptr
+	StackTrace []uintptr // inner to outer
 }
 
 // NewEvent creates a glog.Event from the logged event's severity,

--- a/xerrors.go
+++ b/xerrors.go
@@ -1,0 +1,22 @@
+package glog
+
+import "golang.org/x/xerrors"
+
+// ErrorArg captures information about an error passed as an argument.
+// It is passed to backends as a data arg.
+type ErrorArg struct {
+	Error error
+}
+
+// RootCause returns the innermost error.
+func (xe ErrorArg) RootCause() error {
+	err := xe.Error
+	for {
+		wrapper, ok := err.(xerrors.Wrapper)
+		if !ok {
+			break
+		}
+		err = wrapper.Unwrap()
+	}
+	return err
+}


### PR DESCRIPTION
This allows backends to access the stack trace contained within the error.

Also, reverse the stack frame info returned from errgo to what glog.NewEvent
expects when it stitches the frames together.