### PR TITLE
glog_backend: Propagate error types passed directly to glog as an explicit ErrorArg

### DIFF
--- a/glog_backend.go
+++ b/glog_backend.go
@@ -69,6 +69,11 @@ func filterData(args []interface{}) ([]interface{}, []interface{}) {
 			dataArgs = append(dataArgs, argd.d)
 		} else {
 			realArgs = append(realArgs, arg)
+			// PATCH(jwoglom): Propagate an error type passed directly to
+			// glog as an implicit glog.ErrorArg
+			if errarg, ok := arg.(error); ok {
+				dataArgs = append(dataArgs, ErrorArg{errarg})
+			}
 		}
 	}
 	return realArgs, dataArgs


### PR DESCRIPTION
This change works around some unfortunate behavior which occurs
when glog splits arguments into "real args", which are passed to
the log invocation for display as strings, and "data" args, which
are only sent to registered glog backends.

The problem occurs when a raw error type is passed to glog.
It does not implement the data{} interface, so it is calculated
as a "real arg" and passed to the log call which prints the error
text as a string to the screen. However that means that the raw
error object cannot be accessed from a glog backend.

For Go-Sentry integration, this allows the raw error type to be
read and frames extracted from the traceback when using xerrors.

J=SRE-3390