### PR TITLE
glog: store format string as data argument, remove duplicate error passing

### DIFF
--- a/glog.go
+++ b/glog.go
@@ -639,21 +639,14 @@ func (l *loggingT) printfWithDepth(s severity, extraDepth int, format string, ar
 	mess := make([]byte, len(message))
 	copy(mess, message)
 
-	// If an error is provided in the arguments, pass the first one to backends.
-	// No reason to pass the first one over any other, but it's unlikely to
-	// matter in practice.
-	for _, arg := range args {
-		if err, ok := arg.(error); ok {
-			dataArgs = append(dataArgs, ErrorArg{err})
-			break
-		}
-	}
-
 	if buf.Bytes()[buf.Len()-1] != '\n' {
 		buf.WriteByte('\n')
 	}
 	l.outputWithDepth(s, buf, extraDepth)
 
+	// NOTE(jwoglom): add format string argument as data field
+	// that can be parsed by backends.
+	dataArgs = append(dataArgs, FormatStringArg{format})
 	e := NewEvent(s, mess, dataArgs, extraDepth)
 	eventForBackends(e)
 }

--- a/glog_backend_test.go
+++ b/glog_backend_test.go
@@ -2,6 +2,7 @@ package glog
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -85,6 +86,35 @@ func TestIgnoreData(t *testing.T) {
 	}
 
 	waitForData(t, comm, message, "data1")
+}
+
+func TestFormatString(t *testing.T) {
+	defer resetOutput(setBuffer())
+
+	comm := RegisterBackend()
+
+	message := "error: test error"
+	formatMsg := "error: %s"
+	Errorf(formatMsg, errors.New("test error"))
+
+	if !contains(message, t) {
+		t.Error("glog did not process errorf to stdout")
+	}
+	waitForData(t, comm, message, FormatStringArg{formatMsg})
+}
+
+func TestErrorArgs(t *testing.T) {
+	defer resetOutput(setBuffer())
+
+	comm := RegisterBackend()
+
+	err := errors.New("test error")
+	Error(err)
+
+	if !contains(err.Error(), t) {
+		t.Error("glog did not process error message to stdout")
+	}
+	waitForData(t, comm, err.Error(), ErrorArg{err})
 }
 
 func waitForData(t *testing.T, comm <-chan Event, expectedMessage string, expectedData ...interface{}) {

--- a/xerrors.go
+++ b/xerrors.go
@@ -20,3 +20,10 @@ func (xe ErrorArg) RootCause() error {
 	}
 	return err
 }
+
+// FormatStringArg is used to capture the raw format string passed to glog,
+// which often contains an error message without identifying details that
+// can be used to help group the message.
+type FormatStringArg struct {
+	Format string
+}


### PR DESCRIPTION
The FormatStringArg will allow glog backends to receive the
raw first argument to an Errorf call, which can then be used
to more accurately determine an error type.

Removes duplicate code that passes error arguments as
ErrorArgs -- this is now performed in filterData, so
this special code in printfWithDepth is not needed anymore.

J=SRE-3390
TEST=auto
  Added test for format string and error arg behavior