### PR TITLE
Fix ExternalOutput return value.

### DIFF
--- a/glog.go
+++ b/glog.go
@@ -95,7 +95,8 @@ var ExternalOutput externalWriter
 type externalWriter struct{}
 
 func (er externalWriter) Write(b []byte) (n int, err error) {
-	return logging.printWithDepth(infoLog, 3, string(b)), nil
+	logging.printWithDepth(infoLog, 3, string(b))
+	return len(b), nil
 }
 
 // severity identifies the sort of log: info, warning etc. It also implements


### PR DESCRIPTION
Per io.Writer docs, Write must not return a written count that's greater
than the provided buffer's size, which will happen here due to the extra
formatting glog applies.

Among other potential problems, this has been observed to break
redirecting stdout from an exec.Cmd to this writer.
