### PR TITLE
Make output writer configurable.

### DIFF
--- a/glog_test.go
+++ b/glog_test.go
@@ -28,12 +28,8 @@ import (
 
 var fakeStdout bytes.Buffer
 
-type bufWriter struct{ *bytes.Buffer }
-
-func (bufWriter) Flush() {}
-
 func setBuffer() *bytes.Buffer {
-	output = bufWriter{&fakeStdout}
+	SetOutput(&fakeStdout)
 	return &fakeStdout
 }
 


### PR DESCRIPTION
For example, to be able to write a tool that can write structured data
to stdout while using packages that use glog.